### PR TITLE
Update .readthedocs.yaml

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -14,11 +14,18 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+
 # Read the Docs configuration file
 # See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
 
 # Required
 version: 2
+
+# Specify the operating system for the build
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.7"
 
 # Build documentation in the docs/ directory with Sphinx
 sphinx:
@@ -34,6 +41,7 @@ sphinx:
 
 # Optionally set the version of Python and requirements required to build your docs
 python:
-  version: 3.7
-  install:
-    - requirements: docs/requirements.txt
+   install:
+   - requirements: docs/requirements.txt
+
+


### PR DESCRIPTION
As of Oct 16, ReadTheDocs has migrated from build.image to build.os : https://blog.readthedocs.com/use-build-os-config/

This commit, uses build.os for future RTD builds.